### PR TITLE
Merge in ProjectCypress fork to fix `Unexpected token ;` error in map reduce fn

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    quality-measure-engine (3.1.1)
+    quality-measure-engine (3.1.2)
       delayed_job_mongoid (~> 2.1.0)
       mongoid (~> 4.0.0)
       moped (~> 2.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    quality-measure-engine (3.1.0)
+    quality-measure-engine (3.1.1)
       delayed_job_mongoid (~> 2.1.0)
       mongoid (~> 4.0.0)
       moped (~> 2.0.0)

--- a/lib/qme/map/map_reduce_builder.rb
+++ b/lib/qme/map/map_reduce_builder.rb
@@ -32,6 +32,9 @@ module QME
           if !vars.has_key?('enable_rationale')
             vars['enable_rationale'] = false
           end
+          if !vars.has_key?('short_circuit')
+            vars['short_circuit'] = false
+          end
           vars
         end
 

--- a/lib/qme/map/map_reduce_builder.rb
+++ b/lib/qme/map/map_reduce_builder.rb
@@ -102,6 +102,8 @@ module QME
             <% end %>
             <%= init_js_frameworks %>
             #{@measure_def.map_fn}
+            var res = hqmfjs.calculate(new hQuery.Patient(patient), effective_date,correlation_id);
+            if (res['IPP'] > 0) emit(ObjectId(), res);
           };
           "
         end

--- a/lib/qme/map/map_reduce_executor.rb
+++ b/lib/qme/map/map_reduce_executor.rb
@@ -14,7 +14,7 @@ module QME
       # Create a new Executor for a specific measure, effective date and patient population.
       # @param [String] measure_id the measure identifier
       # @param [String] sub_id the measure sub-identifier or null if the measure is single numerator
-      # @param [Hash] parameter_values a hash that may contain the following keys: 'effective_date' the measurement period end date, 'test_id' an identifier for a specific set of patients
+      # @param [Hash] parameter_values a hash that may contain the following keys: 'effective_date' the measurement period end date, 'correlation_id' an identifier for a specific set of patients
       def initialize(measure_id,sub_id, parameter_values)
 
         @measure_id = measure_id
@@ -38,7 +38,7 @@ module QME
         match = {'value.measure_id' => @measure_id,
                  'value.sub_id'           => @sub_id,
                  'value.effective_date'   => @parameter_values['effective_date'],
-                 'value.test_id'          => @parameter_values['test_id'],
+                 'value.correlation_id'          => @parameter_values['correlation_id'],
                  'value.manual_exclusion' => {'$in' => [nil, false]}}
 
         if(filters)
@@ -80,7 +80,7 @@ module QME
         match = {'value.measure_id' => @measure_id,
                  'value.sub_id'           => @sub_id,
                  'value.effective_date'   => @parameter_values['effective_date'],
-                 'value.test_id'          => @parameter_values['test_id'],
+                 'value.correlation_id'          => @parameter_values['correlation_id'],
                  'value.manual_exclusion' => {'$in' => [nil, false]}}
 
         keys = @measure_def.population_ids.keys - [QME::QualityReport::OBSERVATION, "stratification"]
@@ -214,7 +214,7 @@ module QME
                          :reduce => "function(key, values){return values;}",
                          :out => {:reduce => 'patient_cache', :sharded => true},
                          :finalize => measure.finalize_function,
-                         :query => {:medical_record_number => patient_id, :test_id => @parameter_values["test_id"]})
+                         :query => {:medical_record_number => patient_id, :correlation_id => @parameter_values["correlation_id"]})
         QME::ManualExclusion.apply_manual_exclusions(@measure_id,@sub_id)
 
       end
@@ -229,7 +229,7 @@ module QME
                                   :reduce => "function(key, values){return values;}",
                                   :out => {:inline => true},
                                   :raw => true,
-                                  :query => {:medical_record_number => patient_id, :test_id => @parameter_values["test_id"]})
+                                  :query => {:medical_record_number => patient_id, :correlation_id => @parameter_values["correlation_id"]})
 
         raise result['err'] if result['ok']!=1
         result['results'][0]['value']

--- a/lib/qme/map/measure_calculation_job.rb
+++ b/lib/qme/map/measure_calculation_job.rb
@@ -2,7 +2,7 @@ module QME
   module MapReduce
     # A delayed_job that allows for measure calculation by a delayed_job worker. Can be created as follows:
     #
-    #     Delayed::Job.enqueue QME::MapRedude::MeasureCalculationJob.new(quality_report, :effective_date => 1291352400, :test_id => xyzzy)
+    #     Delayed::Job.enqueue QME::MapRedude::MeasureCalculationJob.new(quality_report, :effective_date => 1291352400, :correlation_id => xyzzy)
     #
     # MeasureCalculationJob will check to see if a measure has been calculated before running the calculation. It will do this by
     # checking the status of the quality report that this calculation job was created with.

--- a/lib/qme/version.rb
+++ b/lib/qme/version.rb
@@ -1,3 +1,3 @@
 module QME
-  VERSION = "3.1.0"
+  VERSION = "3.1.1"
 end

--- a/lib/qme/version.rb
+++ b/lib/qme/version.rb
@@ -1,3 +1,3 @@
 module QME
-  VERSION = "3.1.1"
+  VERSION = "3.1.2"
 end

--- a/test/unit/qme/quality_report_test.rb
+++ b/test/unit/qme/quality_report_test.rb
@@ -33,7 +33,7 @@ class QualityReportTest < MiniTest::Unit::TestCase
         "last" => "Edwards",
         "gender" => "F",
         "birthdate" => Time.gm(1940, 9, 19).to_i,
-        "test_id" => nil,
+        "correlation_id" => nil,
         "provider_performances" => nil,
         "race" => {
           "code" => "2106-3",


### PR DESCRIPTION
This is a pull request from the [`wrapped_mongo_mr_function` branch of Project Cypress' `quality-measure-engine`](https://github.com/projectcypress/quality-measure-engine/tree/wrapped_mongo_mr_function). At the moment, this branch has _not_ been merged into Project Cypress' QME `master` branch. We should take that into account to monitor future changesets on that project to make sure that we get the final version of this fix.

This pull request includes fixes for the `Unexpected token ;` error we have experienced in the NIH NLM quality measure bundle `map_fn` by wrapping `@measure_def.map_fn` in `function()` if it was improperly defined in the measure bundle.

Beyond that, it also essentially re-bases our fork on Project Cypress' QME fork `master` branch by including the other change of making a default `short_circuit` value.

One thing to note, however, is that in the same changeset that fixes the `map_fn`, it also changes the name of a parameter from `test_id` to `correlation_id` which may or may not have ramifications outside this gem. That said, this variable name change is reflected in updated tests in the same changeset. Perhaps since our application does not use this attribute at the moment, we will not see any side-effects; however, we might want to be prepared to update some of our other gem forks in accordance with this change.
