### PR TITLE
Bring q-centrix/QME up to date with projectcypress/QME

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    quality-measure-engine (3.1.1)
+    quality-measure-engine (3.1.2)
       delayed_job_mongoid (~> 2.1.0)
       mongoid (~> 4.0.0)
       moped (~> 2.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    quality-measure-engine (3.1.0)
+    quality-measure-engine (3.1.1)
       delayed_job_mongoid (~> 2.1.0)
       mongoid (~> 4.0.0)
       moped (~> 2.0.0)

--- a/lib/qme/map/map_reduce_builder.rb
+++ b/lib/qme/map/map_reduce_builder.rb
@@ -32,6 +32,9 @@ module QME
           if !vars.has_key?('enable_rationale')
             vars['enable_rationale'] = false
           end
+          if !vars.has_key?('short_circuit')
+            vars['short_circuit'] = false
+          end
           vars
         end
 

--- a/lib/qme/version.rb
+++ b/lib/qme/version.rb
@@ -1,3 +1,3 @@
 module QME
-  VERSION = "3.1.0"
+  VERSION = "3.1.1"
 end

--- a/lib/qme/version.rb
+++ b/lib/qme/version.rb
@@ -1,3 +1,3 @@
 module QME
-  VERSION = "3.1.1"
+  VERSION = "3.1.2"
 end


### PR DESCRIPTION
`q-centrix/quality-measure-engine` was forked from `OSEHRA/quality-measure-engine` which has code causing an error `failed with error 16722: "exception: SyntaxError: Unexpected token ;` when processing `QualityReport`s.

Merging `projectcypress/quality-measure-engine` master branch into `q-centrix/quality-measure-engine` should address this issue without having to use the [`wrapped_mongo_mr_function`](https://github.com/projectcypress/quality-measure-engine/tree/wrapped_mongo_mr_function) branch of `projectcypress/quality-measure-engine` as we have in our [`chores/merge_project_cypress`](https://github.com/q-centrix/quality-measure-engine/tree/chores/merge_project_cypress) branch.
