### PR TITLE
Revert "Revert "Pull ruby-zip commit into master""

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,8 @@ PATH
       delayed_job_mongoid (~> 2.1.0)
       mongoid (~> 4.0.0)
       moped (~> 2.0.0)
-      rubyzip (~> 0.9.9)
+      rubyzip (>= 1.0.0)
+      zip-zip
 
 GEM
   remote: https://rubygems.org/
@@ -39,15 +40,15 @@ GEM
     arel (5.0.1.20140414130214)
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
-    bson (2.3.0)
+    bson (3.2.6)
     builder (3.2.2)
     codeclimate-test-reporter (0.4.8)
       simplecov (>= 0.7.1, < 1.0.0)
     coderay (1.1.0)
-    connection_pool (2.0.0)
+    connection_pool (2.2.0)
     debug_inspector (0.0.2)
-    delayed_job (4.0.3)
-      activesupport (>= 3.0, < 4.2)
+    delayed_job (4.1.1)
+      activesupport (>= 3.0, < 5.0)
     delayed_job_mongoid (2.1.0)
       delayed_job (>= 3.0, < 5)
       mongoid (>= 3.0, < 5)
@@ -63,13 +64,13 @@ GEM
     method_source (0.8.2)
     mime-types (1.25.1)
     minitest (5.4.0)
-    mongoid (4.0.0)
+    mongoid (4.0.2)
       activemodel (~> 4.0)
       moped (~> 2.0.0)
       origin (~> 2.1)
       tzinfo (>= 0.3.37)
-    moped (2.0.0)
-      bson (~> 2.2)
+    moped (2.0.7)
+      bson (~> 3.0)
       connection_pool (~> 2.0)
       optionable (~> 0.2.0)
     multi_json (1.10.1)
@@ -107,7 +108,7 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rake (10.3.2)
-    rubyzip (0.9.9)
+    rubyzip (1.1.7)
     simplecov (0.9.0)
       docile (~> 1.1.0)
       multi_json
@@ -131,6 +132,8 @@ GEM
       polyglot (>= 0.3.1)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
+    zip-zip (0.3)
+      rubyzip (>= 1.0.0)
 
 PLATFORMS
   ruby

--- a/quality-measure-engine.gemspec
+++ b/quality-measure-engine.gemspec
@@ -19,7 +19,8 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency 'moped', '~> 2.0.0'
   gem.add_dependency 'mongoid', '~> 4.0.0'
-  gem.add_dependency 'rubyzip', '~> 0.9.9'
+  gem.add_dependency 'rubyzip', '>= 1.0.0'
+  gem.add_dependency 'zip-zip' # will load compatibility for old rubyzip API
   gem.add_dependency 'delayed_job_mongoid', '~> 2.1.0'
 
   gem.add_development_dependency "minitest", "~> 5.4.0"


### PR DESCRIPTION
Reverts q-centrix/quality-measure-engine#5

1.0+ required by `axlsx` gem, used in `q-centrix/web`
