### PR TITLE
[WIP] Add facility_id to facilitate (pun intended) multitenancy

### DIFF
--- a/lib/qme/map/map_reduce_builder.rb
+++ b/lib/qme/map/map_reduce_builder.rb
@@ -104,6 +104,9 @@ module QME
         if @params['test_id'] && @params['test_id'].class==BSON::ObjectId
           reduce += "  patient.test_id = new ObjectId(\"#{@params['test_id']}\");\n"
         end
+        if @params['facility_id']
+          reduce += "  patient.facility_id = \"#{@params['facility_id']}\";\n"
+        end
         if @measure_def.sub_id
           reduce += "  patient.sub_id = \"#{@measure_def.sub_id}\";\n"
         end

--- a/lib/qme/map/map_reduce_executor.rb
+++ b/lib/qme/map/map_reduce_executor.rb
@@ -197,6 +197,9 @@ module QME
       # that the record belongs to, such as numerator, etc.
       def map_records_into_measure_groups(prefilter={})
         measure = Builder.new(get_db(), @measure_def, @parameter_values)
+        prefilter = (prefilter || {}).merge({
+          :facility_id => @parameter_values['facility_id']
+        })
         get_db().command(:mapreduce => 'records',
                          :map => measure.map_function,
                          :reduce => "function(key, values){return values;}",

--- a/lib/qme/map/map_reduce_executor.rb
+++ b/lib/qme/map/map_reduce_executor.rb
@@ -39,6 +39,7 @@ module QME
                  'value.sub_id'           => @sub_id,
                  'value.effective_date'   => @parameter_values['effective_date'],
                  'value.test_id'          => @parameter_values['test_id'],
+                 'value.facility_id'      => @parameter_values['facility_id'],
                  'value.manual_exclusion' => {'$in' => [nil, false]}}
 
         if(filters)
@@ -81,6 +82,7 @@ module QME
                  'value.sub_id'           => @sub_id,
                  'value.effective_date'   => @parameter_values['effective_date'],
                  'value.test_id'          => @parameter_values['test_id'],
+                 'value.facility_id'      => @parameter_values['facility_id'],
                  'value.manual_exclusion' => {'$in' => [nil, false]}}
 
         keys = @measure_def.population_ids.keys - [QME::QualityReport::OBSERVATION, "stratification"]
@@ -214,7 +216,11 @@ module QME
                          :reduce => "function(key, values){return values;}",
                          :out => {:reduce => 'patient_cache', :sharded => true},
                          :finalize => measure.finalize_function,
-                         :query => {:medical_record_number => patient_id, :test_id => @parameter_values["test_id"]})
+                         :query => {
+                           :medical_record_number => patient_id,
+                           :test_id => @parameter_values["test_id"],
+                           :facility_id => @parameter_values["facility_id"]
+                         })
         QME::ManualExclusion.apply_manual_exclusions(@measure_id,@sub_id)
 
       end
@@ -229,7 +235,11 @@ module QME
                                   :reduce => "function(key, values){return values;}",
                                   :out => {:inline => true},
                                   :raw => true,
-                                  :query => {:medical_record_number => patient_id, :test_id => @parameter_values["test_id"]})
+                                  :query => {
+                                    :medical_record_number => patient_id,
+                                    :test_id => @parameter_values["test_id"],
+                                    :facility_id => @parameter_values["facility_id"]
+                                   })
 
         raise result['err'] if result['ok']!=1
         result['results'][0]['value']


### PR DESCRIPTION
In order to be able to segregate QualityReports by facility, add facility_id to the entire QualityReport pipeline, including the MapReduce Builder/Executor. We looked at doing this through test_id but at the end of the day we decided to go with adding our own attribute.
