### PR TITLE
Allows recalculation of patient caches

### DIFF
--- a/lib/qme/map/map_reduce_executor.rb
+++ b/lib/qme/map/map_reduce_executor.rb
@@ -35,11 +35,12 @@ module QME
         filters = @parameter_values["filters"]
 
 
-        match = {'value.measure_id' => @measure_id,
+        match = {'value.measure_id'       => @measure_id,
                  'value.sub_id'           => @sub_id,
                  'value.effective_date'   => @parameter_values['effective_date'],
                  'value.test_id'          => @parameter_values['test_id'],
                  'value.facility_id'      => @parameter_values['facility_id'],
+                 'value.expired_at'       => nil,
                  'value.manual_exclusion' => {'$in' => [nil, false]}}
 
         if(filters)

--- a/lib/qme/map/measure_calculation_job.rb
+++ b/lib/qme/map/measure_calculation_job.rb
@@ -19,9 +19,10 @@ module QME
       end
 
       def perform
-        if !@quality_report.calculated?
+        if !@quality_report.calculated? || @options['recalculate']
           map = QME::MapReduce::Executor.new(@quality_report.measure_id,@quality_report.sub_id, @options.merge('start_time' => Time.now.to_i))
-          if !@quality_report.patients_cached?
+          if @quality_report.patients_cached? || @options['recalculate']
+            @quality_report.expire_patient_results
             tick('Starting MapReduce')
             map.map_records_into_measure_groups(@options['prefilter'])
             tick('MapReduce complete')

--- a/lib/qme/quality_report.rb
+++ b/lib/qme/quality_report.rb
@@ -168,6 +168,10 @@ module QME
      QME::PatientCache.where(patient_cache_matcher)
     end
 
+    def expire_patient_results
+      patient_results.update_all("value.expired_at" => Time.now)
+    end
+
     def measure
       QME::QualityMeasure.where({"hqmf_id"=>self.measure_id, "sub_id" => self.sub_id}).first
     end
@@ -192,6 +196,7 @@ module QME
                'value.effective_date'   => self.effective_date,
                'value.test_id'          => test_id,
                'value.facility_id'      => facility_id,
+               'value.expired_at'       => nil,
                'value.manual_exclusion' => {'$in' => [nil, false]}}
 
       if(filters)


### PR DESCRIPTION
In order to recalculate patient caches we want to use the recalculate
option in the calculation job. Using the recalculate flag we can force
an expiration of results.

We also added an expired_at value to the patient caches in order for
them not to be included in future calculations and results. These can be
purged at any time in the future.

https://www.pivotaltracker.com/story/show/138166087