### PR TITLE
Make Delayed Job only dev dependent

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,6 @@ PATH
   remote: .
   specs:
     quality-measure-engine (3.1.2)
-      delayed_job_mongoid (~> 2.2.0)
       mongoid (~> 5.0.0)
       rubyzip (>= 1.0.0)
       zip-zip
@@ -107,7 +106,7 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rake (11.1.2)
-    rubyzip (1.1.7)
+    rubyzip (1.2.1)
     simplecov (0.9.0)
       docile (~> 1.1.0)
       multi_json
@@ -133,6 +132,7 @@ PLATFORMS
 
 DEPENDENCIES
   codeclimate-test-reporter
+  delayed_job_mongoid (~> 2.2.0)
   minitest (~> 5.4.0)
   pry
   pry-nav
@@ -143,4 +143,4 @@ DEPENDENCIES
   simplecov (~> 0.9.0)
 
 BUNDLED WITH
-   1.13.1
+   1.13.2

--- a/quality-measure-engine.gemspec
+++ b/quality-measure-engine.gemspec
@@ -20,8 +20,8 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'mongoid', '~> 5.0.0'
   gem.add_dependency 'rubyzip', '>= 1.0.0'
   gem.add_dependency 'zip-zip'
-  gem.add_dependency 'delayed_job_mongoid', '~> 2.2.0'
-
+  
+  gem.add_development_dependency 'delayed_job_mongoid', '~> 2.2.0'
   gem.add_development_dependency "minitest", "~> 5.4.0"
   gem.add_development_dependency "simplecov", "~> 0.9.0"
   gem.add_development_dependency "rails", "~> 4.1.7"


### PR DESCRIPTION
Pivotal: https://www.pivotaltracker.com/story/show/138447789
Associated to: https://github.com/q-centrix/q-apps-models/pull/254, https://github.com/q-centrix/ecqm-api/pull/172

Delayed Job Mongoid is now only used in development. 