### PR TITLE
Adds a class to inject the effective start date

### DIFF
--- a/lib/qme/map/effective_start_date_injector.rb
+++ b/lib/qme/map/effective_start_date_injector.rb
@@ -1,0 +1,31 @@
+module QME
+  module MapReduce
+    # Injects the effective start date into the map reduce function of a measure
+    # if provided
+    class EffectiveStartDateInjector
+      def initialize(map_fn:, effective_start_date:)
+        @map_fn = map_fn
+        @effective_start_date = effective_start_date
+      end
+
+      def execute
+        return map_fn unless effective_start_date
+
+        self.map_fn = map_fn.gsub(
+          /(<%= effective_date %>;)/,
+          '\1 var effective_start_date = <%= effective_start_date %>;'
+        )
+        self.map_fn = map_fn.gsub(
+          "MeasurePeriod.low.date = new Date(1000*(effective_date+60));\n  MeasurePeriod.low.date.setFullYear(MeasurePeriod.low.date.getFullYear()-1);",
+          'MeasurePeriod.low.date = new Date(1000*effective_start_date);'
+        )
+        map_fn
+      end
+
+      private
+
+      attr_reader :effective_start_date
+      attr_accessor :map_fn
+    end
+  end
+end

--- a/lib/qme/map/map_reduce_builder.rb
+++ b/lib/qme/map/map_reduce_builder.rb
@@ -79,7 +79,11 @@ module QME
         # taken from the supplied params
         # always true for actual measures, not always true for unit tests
         if (@measure_def.map_fn)
-          template = ERB.new(@measure_def.map_fn)
+          map_fn = QME::MapReduce::EffectiveStartDateInjector.new(
+            map_fn: @measure_def.map_fn,
+            effective_start_date: @params['effective_start_date']
+          ).execute
+          template = ERB.new(map_fn)
           context = Context.new(@db, @params)
           @measure_def.map_fn = template.result(context.get_binding)
         end

--- a/lib/qme/map/map_reduce_builder.rb
+++ b/lib/qme/map/map_reduce_builder.rb
@@ -111,6 +111,10 @@ module QME
         if @params['facility_id']
           reduce += "  patient.facility_id = \"#{@params['facility_id']}\";\n"
         end
+        if @params['effective_start_date']
+          reporting_period_start = @params['effective_start_date']
+          reduce += "  patient.effective_start_date = #{@params['effective_start_date']};\n"
+        end
         if @measure_def.sub_id
           reduce += "  patient.sub_id = \"#{@measure_def.sub_id}\";\n"
         end

--- a/lib/qme/map/map_reduce_executor.rb
+++ b/lib/qme/map/map_reduce_executor.rb
@@ -35,13 +35,14 @@ module QME
         filters = @parameter_values["filters"]
 
 
-        match = {'value.measure_id'       => @measure_id,
-                 'value.sub_id'           => @sub_id,
-                 'value.effective_date'   => @parameter_values['effective_date'],
-                 'value.test_id'          => @parameter_values['test_id'],
-                 'value.facility_id'      => @parameter_values['facility_id'],
-                 'value.expired_at'       => nil,
-                 'value.manual_exclusion' => {'$in' => [nil, false]}}
+        match = {'value.measure_id'           => @measure_id,
+                 'value.sub_id'               => @sub_id,
+                 'value.effective_date'       => @parameter_values['effective_date'],
+                 'value.effective_start_date' => @parameter_values['effective_start_date'],
+                 'value.test_id'              => @parameter_values['test_id'],
+                 'value.facility_id'          => @parameter_values['facility_id'],
+                 'value.expired_at'           => nil,
+                 'value.manual_exclusion'     => {'$in' => [nil, false]}}
 
         if(filters)
           if (filters['races'] && filters['races'].size > 0)
@@ -83,11 +84,12 @@ module QME
       def calculate_supplemental_data_elements
 
         match = {'value.measure_id' => @measure_id,
-                 'value.sub_id'           => @sub_id,
-                 'value.effective_date'   => @parameter_values['effective_date'],
-                 'value.test_id'          => @parameter_values['test_id'],
-                 'value.facility_id'      => @parameter_values['facility_id'],
-                 'value.manual_exclusion' => {'$in' => [nil, false]}}
+                 'value.sub_id'               => @sub_id,
+                 'value.effective_date'       => @parameter_values['effective_date'],
+                 'value.effective_start_date' => @parameter_values['effective_start_date'],
+                 'value.test_id'              => @parameter_values['test_id'],
+                 'value.facility_id'          => @parameter_values['facility_id'],
+                 'value.manual_exclusion'     => {'$in' => [nil, false]}}
 
         keys = @measure_def.population_ids.keys - [QME::QualityReport::OBSERVATION, "stratification"]
         supplemental_data = Hash[*keys.map{|k| [k,{QME::QualityReport::RACE => {},

--- a/lib/quality-measure-engine.rb
+++ b/lib/quality-measure-engine.rb
@@ -10,6 +10,7 @@ require 'qme/quality_report'
 require 'qme/patient_cache'
 require 'qme/manual_exclusion'
 
+require 'qme/map/effective_start_date_injector'
 require 'qme/map/map_reduce_builder'
 require 'qme/map/map_reduce_executor'
 require 'qme/map/measure_calculation_job'

--- a/test/unit/qme/map/effective_start_date_injector_test.rb
+++ b/test/unit/qme/map/effective_start_date_injector_test.rb
@@ -1,0 +1,33 @@
+require 'test_helper'
+
+class EffectiveStartDateInjectorTest < MiniTest::Unit::TestCase
+  def setup
+    @map_fn = <<-MAP_FN
+      var effective_date = <%= effective_date %>;
+      MeasurePeriod.low.date = new Date(1000*(effective_date+60));\n  MeasurePeriod.low.date.setFullYear(MeasurePeriod.low.date.getFullYear()-1);",
+    MAP_FN
+  end
+
+  def test_execute_no_effective_start_date
+    subject = QME::MapReduce::EffectiveStartDateInjector.new(
+      map_fn: @map_fn,
+      effective_start_date: nil
+    )
+
+    assert_equal subject.execute, @map_fn
+  end
+
+  def test_execute_with_effective_start_date
+    subject = QME::MapReduce::EffectiveStartDateInjector.new(
+      map_fn: @map_fn,
+      effective_start_date: "foo"
+    )
+
+    expected = <<-EXPECTED
+      var effective_date = <%= effective_date %>; var effective_start_date = <%= effective_start_date %>;
+      MeasurePeriod.low.date = new Date(1000*effective_start_date);\",
+    EXPECTED
+
+    assert_equal subject.execute, expected
+  end
+end

--- a/test/unit/qme/quality_report_test.rb
+++ b/test/unit/qme/quality_report_test.rb
@@ -148,16 +148,19 @@ class QualityReportTest < MiniTest::Unit::TestCase
 
   def test_patient_cache_matcher
     effective_date = Time.gm(2010, 9, 19).to_i
+    effective_start_date = Time.gm(2010, 1, 1).to_i
     qr = QME::QualityReport.find_or_create(
       'test2',
       'b',
-      'effective_date' => effective_date
+      'effective_date' => effective_date,
+      'effective_start_date' => effective_start_date
     )
 
     expected_results = {
       'value.measure_id' => 'test2',
       'value.sub_id' => 'b',
       'value.effective_date' => effective_date,
+      'value.effective_start_date' => effective_start_date,
       'value.test_id' => nil,
       'value.facility_id' => nil,
       'value.expired_at' => nil,


### PR DESCRIPTION
This allows us to use the effective start date to set the low value of
the measure period in every measure. This is used to determine which
patients are used within each measure.

If no effective start date is provided the measures use the original
code which calculates the low date based on the effective date + 60
seconds - 1 year.

If this is used within Ecqm then the reports will no longer create quality report result patient records for patients that fall outside this timeframe. HOWEVER, please note that existing quality report result patient records are never deleted and therefore will still be in the result listing, but not included in any calculation. This will cause confusion and should be considered a bug. We will need to address this in Ecqm.