### PR TITLE
ACS-1755 Remove old ECQM

### DIFF
--- a/lib/quality-measure-engine.rb
+++ b/lib/quality-measure-engine.rb
@@ -1,6 +1,5 @@
 require "bundler/setup"
 
-require 'delayed_job_mongoid'
 require 'zip/zip'
 
 require "qme/version"

--- a/quality-measure-engine.gemspec
+++ b/quality-measure-engine.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'mongoid', '~> 7.0.0'
   gem.add_dependency 'rubyzip', '>= 1.0.0'
   gem.add_dependency 'zip-zip'
-  gem.add_dependency 'delayed_job_mongoid'
 
   gem.add_development_dependency "minitest", "~> 5.4.0"
   gem.add_development_dependency "simplecov", "~> 0.9.0"


### PR DESCRIPTION
JIRA: https://qcentrix.atlassian.net/browse/ACS-1755

main pr: 
https://github.com/q-centrix/web/pull/4378

this pr:
- remove `delayed_job_mongoid`, with use postgre as delayed job backend, this gem confuses the delayed job references we have (from `include Delayed::RecurringJob`) and created fail specs https://circleci.com/gh/q-centrix/web/30179?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-checks-link